### PR TITLE
Update Guild.js

### DIFF
--- a/structures/Guild.js
+++ b/structures/Guild.js
@@ -1,4 +1,5 @@
 const { Structures } = require('discord.js');
+const { defaultPrefix } = require('../config.js');
 
 Structures.extend('Guild', Guild => {
     class GuildExt extends Guild {


### PR DESCRIPTION
defaultPrefix should be defined to return as a fallback if this.get('prefix') isn't defined.